### PR TITLE
ModernGov template page generation module

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,187 @@
+name: Test the localgov_moderngov module
+
+on:
+  push:
+    branches:
+      - '1.x'
+  pull_request:
+    branches:
+      - '1.x'
+
+jobs:
+
+  build:
+    name: Install LocalGov Drupal
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - localgov-version: "2.x"
+            drupal-version: "~9.3"
+            php-version: "7.4"
+
+    steps:
+
+      - name: Save git branch and git repo names to env if this is not a pull request
+        if: github.event_name != 'pull_request'
+        run: |
+          echo "GIT_BASE=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+          echo "GIT_BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+          echo "GIT_REPO=${GITHUB_REPOSITORY}" >> $GITHUB_ENV
+
+      - name: Save git branch and git repo names to env if this is a pull request
+        if: github.event_name == 'pull_request'
+        run: |
+          echo "GIT_BASE=${GITHUB_BASE_REF}" >> $GITHUB_ENV
+          echo "GIT_BRANCH=${GITHUB_HEAD_REF}" >> $GITHUB_ENV
+          echo "GIT_REPO=${{ github.event.pull_request.head.repo.full_name }}" >> $GITHUB_ENV
+
+      - name: Set composer branch reference for version branches
+        if: endsWith(github.ref, '.x')
+        run: echo "COMPOSER_REF=${GIT_BRANCH}-dev" >> $GITHUB_ENV
+
+      - name: Set composer branch reference for non-version branches
+        if: endsWith(github.ref, '.x') == false
+        run: echo "COMPOSER_REF=dev-${GIT_BRANCH}" >> $GITHUB_ENV
+
+      - name: Get the latest tagged release for branch version
+        run: |
+          LATEST_RELEASE=$(curl -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/${GITHUB_REPOSITORY}/git/matching-refs/tags/${GIT_BASE%'.x'} | grep -Po '(?<=refs/tags/)[^"]+' | tail -1)
+          if [ -z $LATEST_RELEASE ]; then LATEST_RELEASE=1; fi
+          echo "LATEST_RELEASE=${LATEST_RELEASE}" >> $GITHUB_ENV
+
+      - name: Cached workspace
+        uses: actions/cache@v2
+        with:
+          path: ./html
+          key: localgov-build-${{ matrix.localgov-version }}-${{ matrix.drupal-version }}-${{ matrix.php-version }}-${{ github.run_id }}-${{ secrets.CACHE_VERSION }}
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+
+      - name: Clone drupal_container
+        uses: actions/checkout@v2
+        with:
+          repository: localgovdrupal/drupal-container
+          ref: php${{ matrix.php-version }}
+
+      - name: Create LocalGov Drupal project
+        run: |
+          composer create-project --stability dev --no-install localgovdrupal/localgov-project ./html "${{ matrix.localgov-version }}"
+          composer --working-dir=./html require --no-install localgovdrupal/localgov:${{ matrix.localgov-version }}-dev
+          composer --working-dir=./html require --no-install drupal/core-recommended:${{ matrix.drupal-version }} drupal/core-composer-scaffold:${{ matrix.drupal-version }} drupal/core-project-message:${{ matrix.drupal-version }} drupal/core-dev:${{ matrix.drupal-version }}
+          composer --working-dir=./html install
+
+      - name: Obtain the test target from the repo that triggered this workflow
+        run: |
+          composer --working-dir=html config repositories.1 vcs git@github.com:${GIT_REPO}.git
+          composer global config github-oauth.github.com ${{ github.token }}
+          composer --working-dir=./html require --with-all-dependencies localgovdrupal/${{ github.event.repository.name }}:"${COMPOSER_REF} as ${LATEST_RELEASE}"
+
+  phpcs:
+    name: Coding standards checks
+    needs: build
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - localgov-version: "2.x"
+            drupal-version: "~9.3"
+            php-version: "7.4"
+
+    steps:
+
+      - name: Cached workspace
+        uses: actions/cache@v2
+        with:
+          path: ./html
+          key: localgov-build-${{ matrix.localgov-version }}-${{ matrix.drupal-version }}-${{ matrix.php-version }}-${{ github.run_id }}-${{ secrets.CACHE_VERSION }}
+          restore-keys: |
+            localgov-build-${{ matrix.localgov-version }}-${{ matrix.drupal-version }}-${{ matrix.php-version }}-
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+
+      - name: Run coding standards checks
+        run: |
+          cd html
+          ./bin/phpcs -p
+
+  phpstan:
+    name: Deprecated code checks
+    needs: build
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - localgov-version: "2.x"
+            drupal-version: "~9.3"
+            php-version: "7.4"
+
+    steps:
+
+      - name: Cached workspace
+        uses: actions/cache@v2
+        with:
+          path: ./html
+          key: localgov-build-${{ matrix.localgov-version }}-${{ matrix.drupal-version }}-${{ matrix.php-version }}-${{ github.run_id }}-${{ secrets.CACHE_VERSION }}
+          restore-keys: |
+            localgov-build-${{ matrix.localgov-version }}-${{ matrix.drupal-version }}-${{ matrix.php-version }}-
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+
+      - name: Run deprecated code checks
+        run: |
+          cd html
+          ./bin/phpstan analyse -c ./phpstan.neon ./web/profiles/contrib/localgov/ ./web/modules/contrib/localgov_*
+
+  phpunit:
+    name: PHPUnit tests
+    needs: build
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - localgov-version: "2.x"
+            drupal-version: "~9.3"
+            php-version: "7.4"
+
+    steps:
+
+      - name: Clone Drupal container
+        uses: actions/checkout@v2
+        with:
+          repository: localgovdrupal/drupal-container
+          ref: php${{ matrix.php-version }}
+
+      - name: Cached workspace
+        uses: actions/cache@v2
+        with:
+          path: ./html
+          key: localgov-build-${{ matrix.localgov-version }}-${{ matrix.drupal-version }}-${{ matrix.php-version }}-${{ github.run_id }}-${{ secrets.CACHE_VERSION }}
+          restore-keys: |
+            localgov-build-${{ matrix.localgov-version }}-${{ matrix.drupal-version }}-${{ matrix.php-version }}-
+
+      - name: Start Docker environment
+        run: docker-compose -f docker-compose.yml up -d
+
+      - name: Run PHPUnit tests
+        run: |
+          mkdir -p ./html/web/sites/simpletest && chmod 777 ./html/web/sites/simpletest
+          docker exec -t drupal bash -c 'chown docker:docker -R /var/www/html'
+          docker exec -u docker -t drupal bash -c "cd /var/www/html && ./bin/paratest --processes=4"

--- a/localgov_moderngov.info.yml
+++ b/localgov_moderngov.info.yml
@@ -1,0 +1,6 @@
+name: LocalGov ModernGov
+type: module
+description: Presents a single page with Modern.Gov tags
+package: LocalGov Drupal
+core: 8.x
+core_version_requirement: ^8 || ^9

--- a/localgov_moderngov.module
+++ b/localgov_moderngov.module
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * @file
+ * Hook implementations.
+ */
+
+declare(strict_types = 1);
+
+use Drupal\localgov_moderngov\Constants;
+ 
+/**
+ * Implements hook_theme.
+ *
+ * Themes:
+ * - ModernGov template page.
+ */
+function localgov_moderngov_theme() {
+
+  return [
+    Constants::PAGE_TPL_NAME => [
+      'base hook' => 'page',
+    ],
+  ];
+}
+
+/**
+ * Implements hook_preprocess_hook() for hook_preprocess_html().
+ *
+ * - When in the ModernGov template page, applies appropriate classes on the
+ *   body tag.
+ */
+function localgov_moderngov_preprocess_html(&$vars) {
+
+  $current_route_name = Drupal::service('current_route_match')->getRouteName();
+  $is_moderngov_tpl_page = ($current_route_name === 'localgov_moderngov.modern_gov');
+  if ($is_moderngov_tpl_page) {
+    $vars['attributes']['class'][] = Constants::PAGE_BODY_CLASS;
+  }
+}

--- a/localgov_moderngov.module
+++ b/localgov_moderngov.module
@@ -8,9 +8,9 @@
 declare(strict_types = 1);
 
 use Drupal\localgov_moderngov\Constants;
- 
+
 /**
- * Implements hook_theme.
+ * Implements hook_theme().
  *
  * Themes:
  * - ModernGov template page.

--- a/localgov_moderngov.routing.yml
+++ b/localgov_moderngov.routing.yml
@@ -1,0 +1,11 @@
+localgov_moderngov.modern_gov:
+  path: '/moderngov-template'
+  defaults:
+    _controller: json_decode
+    _title: '{pagetitle}'
+    json: '[]'
+    assoc: 1
+    depth: 2
+    options: 3
+  requirements:
+    _permission: 'access content'

--- a/localgov_moderngov.services.yml
+++ b/localgov_moderngov.services.yml
@@ -1,0 +1,5 @@
+services:
+  localgov_moderngov.html_response_subscriber:
+    class: Drupal\localgov_moderngov\EventSubscriber\HtmlResponseSubscriber
+    tags:
+      - { name: event_subscriber }

--- a/src/Constants.php
+++ b/src/Constants.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Drupal\localgov_moderngov;
+
+/**
+ * Constants for this module.
+ */
+class Constants {
+
+  /**
+   * Twig template used for the ModernGov template page.
+   */
+  const PAGE_TPL_NAME = 'page__moderngov_template';
+
+  /**
+   * Class *attribute* for body tag of ModernGov template page.
+   */
+  const PAGE_BODY_CLASS = 'page--moderngov-template';
+
+}

--- a/src/EventSubscriber/HtmlResponseSubscriber.php
+++ b/src/EventSubscriber/HtmlResponseSubscriber.php
@@ -3,7 +3,7 @@
 namespace Drupal\localgov_moderngov\EventSubscriber;
 
 use Drupal\Core\Render\HtmlResponse;
-use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
@@ -16,12 +16,9 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 class HtmlResponseSubscriber implements EventSubscriberInterface {
 
   /**
-   * Convert all relative URLs to absolute.
-   *
-   * @param \Symfony\Component\HttpKernel\Event\FilterResponseEvent $event
-   *   The event to process.
+   * Converts all relative URLs to absolute.
    */
-  public function onRespond(FilterResponseEvent $event) {
+  public function onRespond(ResponseEvent $event) {
 
     $request = $event->getRequest();
     $route_name = $request->get('_route');

--- a/src/EventSubscriber/HtmlResponseSubscriber.php
+++ b/src/EventSubscriber/HtmlResponseSubscriber.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Drupal\localgov_moderngov\EventSubscriber;
+
+use Drupal\Core\Render\HtmlResponse;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Post processing for the ModernGov template page.
+ *
+ * Processing:
+ * - Converts all relative URLs in the page to absolute URLs.
+ */
+class HtmlResponseSubscriber implements EventSubscriberInterface {
+
+  /**
+   * Convert all relative URLs to absolute.
+   *
+   * @param \Symfony\Component\HttpKernel\Event\FilterResponseEvent $event
+   *   The event to process.
+   */
+  public function onRespond(FilterResponseEvent $event) {
+
+    $request = $event->getRequest();
+    $route_name = $request->get('_route');
+    $response = $event->getResponse();
+    if (!$response instanceof HtmlResponse || $route_name !== 'localgov_moderngov.modern_gov') {
+      return;
+    }
+
+    $request_scheme_and_host = $request->getSchemeAndHttpHost();
+
+    $html = $response->getContent();
+    $html_with_absolute_urls = self::transformRootRelativeUrlsToAbsolute($html, $request_scheme_and_host);
+
+    $response->setContent($html_with_absolute_urls);
+  }
+
+  /**
+   * Converts all root-relative URLs to absolute URLs.
+   *
+   * Based on
+   * Drupal\Component\Utility\Html::transformRootRelativeUrlsToAbsolute()
+   * which processes Html *body* content only.  Whereas here, we process the
+   * entire HTML document.
+   *
+   * @param string $html
+   *   The partial (X)HTML snippet to load. Invalid markup will be corrected on
+   *   import.
+   * @param string $scheme_and_host
+   *   The root URL, which has a URI scheme, host and optional port.
+   *
+   * @return string
+   *   The updated (X)HTML snippet.
+   *
+   * @see Drupal\Component\Utility\Html::transformRootRelativeUrlsToAbsolute()
+   */
+  public static function transformRootRelativeUrlsToAbsolute($html, $scheme_and_host) :string {
+
+    $html_dom = new \DOMDocument();
+    // Ignore warnings during HTML soup loading.
+    @$html_dom->loadHTML($html);
+    $xpath = new \DOMXpath($html_dom);
+
+    $uriAttributes = [
+      'href', 'poster', 'src', 'cite', 'data',
+      'action', 'formaction', 'srcset', 'about',
+    ];
+
+    // Update all root-relative URLs to absolute URLs in the given HTML.
+    foreach ($uriAttributes as $attr) {
+      foreach ($xpath->query("//*[starts-with(@$attr, '/') and not(starts-with(@$attr, '//'))]") as $node) {
+        $node->setAttribute($attr, $scheme_and_host . $node->getAttribute($attr));
+      }
+      foreach ($xpath->query("//*[@srcset]") as $node) {
+        // @see https://html.spec.whatwg.org/multipage/embedded-content.html#attr-img-srcset
+        // @see https://html.spec.whatwg.org/multipage/embedded-content.html#image-candidate-string
+        $image_candidate_strings = explode(',', $node->getAttribute('srcset'));
+        $image_candidate_strings = array_map('trim', $image_candidate_strings);
+        for ($i = 0; $i < count($image_candidate_strings); $i++) {
+          $image_candidate_string = $image_candidate_strings[$i];
+          if ($image_candidate_string[0] === '/' && $image_candidate_string[1] !== '/') {
+            $image_candidate_strings[$i] = $scheme_and_host . $image_candidate_string;
+          }
+        }
+        $node->setAttribute('srcset', implode(', ', $image_candidate_strings));
+      }
+    }
+
+    $html_with_absolute_urls = $html_dom->saveHtml();
+    return $html_with_absolute_urls;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+
+    // This event subscriber needs to know about the route so it needs to have
+    // a priority of 31 or less. To modify headers a priority of 0 or less is
+    // needed.
+    $events[KernelEvents::RESPONSE][] = ['onRespond', -10];
+
+    return $events;
+  }
+
+}

--- a/templates/page--moderngov-template.html.twig
+++ b/templates/page--moderngov-template.html.twig
@@ -1,0 +1,86 @@
+{#
+/**
+ * @file
+ * Default ModernGov page template.
+ *
+ * Non-admin users see "{breadcrumb}", "{content}, and "{sidenav}" instead of
+ * the usual content.
+ *
+ * Available variables:
+ *
+ * General utility variables:
+ * - base_path: The base URL path of the Drupal installation. Will usually be
+ *   "/" unless you have installed Drupal in a sub-directory.
+ * - is_front: A flag indicating if the current page is the front page.
+ * - logged_in: A flag indicating if the user is registered and signed in.
+ * - is_admin: A flag indicating if the user has permission to access
+ *   administration pages.
+ *
+ * Site identity:
+ * - front_page: The URL of the front page. Use this instead of base_path when
+ *   linking to the front page. This includes the language domain or prefix.
+ *
+ * Page content (in order of occurrence in the default page.html.twig):
+ * - messages: Status and error messages. Should be displayed prominently.
+ * - node: Fully loaded node, if there is an automatically-loaded node
+ *   associated with the page and the node ID is the second argument in the
+ *   page's path (e.g. node/12345 and node/12345/revisions, but not
+ *   comment/reply/12345).
+ *
+ * Regions:
+ * - page.header: Items for the header region.
+ * - page.primary_menu: Items for the primary menu region.
+ * - page.secondary_menu: Items for the secondary menu region.
+ * - page.highlighted: Items for the highlighted content region.
+ * - page.help: Dynamic help text, mostly for admin pages.
+ * - page.content: The main content of the current page.
+ * - page.sidebar_first: Items for the first sidebar.
+ * - page.sidebar_second: Items for the second sidebar.
+ * - page.footer: Items for the footer region.
+ * - page.breadcrumb: Items for the breadcrumb region.
+ *
+ * @see template_preprocess_page()
+ * @see html.html.twig
+ *
+ * @ingroup themeable
+ */
+#}
+<div class="layout-container">
+
+  <header role="banner">
+    {{ page.header }}
+  </header>
+
+  {{ page.primary_menu }}
+  {{ page.secondary_menu }}
+
+  <div class="breadcrumb-wrapper">
+    {breadcrumb}
+  </div>
+
+  {{ page.highlighted }}
+
+  {{ page.help }}
+
+  {{ page.content_top }}
+
+  <main role="main">
+    <a id="main-content" tabindex="-1"></a>
+
+    <div class="layout-content">
+      {content}
+    </div>
+
+    <aside class="layout-sidebar-second" role="complementary">
+      {sidenav}
+    </aside>
+
+  </main>
+
+  {% if page.footer %}
+    <footer role="contentinfo">
+      {{ page.footer }}
+    </footer>
+  {% endif %}
+
+</div>

--- a/tests/src/Functional/PageTest.php
+++ b/tests/src/Functional/PageTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\localgov_moderngov\Functional;
+
+use Drupal\user\Entity\Role;
+use Drupal\Tests\BrowserTestBase;
+use Drupal\Tests\Traits\Core\PathAliasTestTrait;
+
+/**
+ * Modern.Gov template page examination.
+ */
+class PageTest extends BrowserTestBase {
+
+  use PathAliasTestTrait;
+
+  /**
+   * Validates a Modern.Gov template page.
+   *
+   * Things we are validating:
+   * - Presence of tokens within the Modern.Gov template page.
+   * - Absolute asset URLs.
+   */
+  public function testModernGovPage() {
+
+    $this->drupalGet("moderngov-template");
+    $this->assertSession()->statusCodeEquals(200);
+
+    // Validate presence of ModernGov tokens.
+    $this->assertSession()->pageTextContains('{pagetitle}');
+    $this->assertSession()->pageTextContains('{content}');
+    $this->assertSession()->pageTextContains('{breadcrumb}');
+    $this->assertSession()->pageTextContains('{sidenav}');
+
+    // Validate absolute asset URLs.  We are sampling the Favicon URL only.
+    $favicon_link_element_list = $this->cssSelect('link[rel="icon"]');
+    $favicon_link_element = current($favicon_link_element_list);
+
+    $favicon_url = $favicon_link_element->getAttribute('href');
+    $this->assertNotNull($favicon_url);
+
+    $favicon_url_parts = parse_url($favicon_url);
+    $favicon_url_has_hostname = array_key_exists('host', $favicon_url_parts);
+    $favicon_url_is_absolute  = $favicon_url_has_hostname;
+    $this->assertTrue($favicon_url_is_absolute);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+
+    parent::setUp();
+
+    $anonymous_role = Role::load('anonymous');
+    $anonymous_role->grantPermission('access content');
+    $anonymous_role->save();
+  }
+
+  /**
+   * Theme used during testing.
+   *
+   * @var string
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
+   * Modules to enable.
+   *
+   * @var array
+   */
+  protected static $modules = [
+    'localgov_moderngov',
+  ];
+
+}


### PR DESCRIPTION
Second incarnation of the Modern.Gov template page module.  I have polished up Eke's original code by:
- Using "localgov" prefixes.
- Used a simpler controller that does nothing other than producing an empty page.  But then allows us to use a custom page template to control the page content.
- As discussed, used DOM-based URL replacement instead of string replacement.  Turned out [Drupal\Component\Utility\Html::transformRootRelativeUrlsToAbsolute()](https://api.drupal.org/api/drupal/core%21lib%21Drupal%21Component%21Utility%21Html.php/function/Html%3A%3AtransformRootRelativeUrlsToAbsolute/9.3.x) only acts on the *body* part of an HTML document instead of the entire document, so had to lift its code and tweak as necessary.

## Recap
To serve as a ModernGov template, a page needs to meet two requirements:
- Uses these tokens in appropriate locations within the page:
  - ```{pagetitle}```
  - ```{breadcrumb}```
  - ```{content}```
  - ```{sidebar}```
- Uses absolute URLs instead of relative URLs.

## How to test
- Install the localgov_moderngov module.  It's **not** in packagist.org yet.  So you will have to grab it from Github.
- Verify the presence of the Modern.Gov tokens (e.g. ```{pagetitle}```) in the page.
- Verify link and asset URLs within the HTML page source. These should all be absolute URLs.

## Remaining issue
While testing, realized that any relative URL sitting inside embedded Javascript (e.g. drupalSettings) won't change to absolute URL.  Not sure how big a problem that is.